### PR TITLE
update go version used in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: '1.20'
       - name: Cache Go modules
         uses: actions/cache@v3
         with:
@@ -51,7 +51,7 @@ jobs:
         run: |
           cat << EOF > version.go
           package opslevel
-  
+
           const clientVersion = "${{ steps.version.outputs.RELEASE_VERSION }}"
           EOF
       - name: Ensure Changelog

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: '1.20'
       - name: Run Tests
         run: |-
           go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...


### PR DESCRIPTION
Recently updated this module to use `go 1.20` - see [go.mod](https://github.com/OpsLevel/opslevel-common/blob/main/go.mod#L3)
Updating our Github Actions to match this.