### PR TITLE
make GetSample() more concise and add tests for it

### DIFF
--- a/.changes/unreleased/Refactor-20240114-015112.yaml
+++ b/.changes/unreleased/Refactor-20240114-015112.yaml
@@ -1,0 +1,3 @@
+kind: Refactor
+body: Change GetSample() logic and add unit tests for GetSample()
+time: 2024-01-14T01:51:12.026644-05:00

--- a/sampler.go
+++ b/sampler.go
@@ -2,14 +2,30 @@ package opslevel_common
 
 import (
 	"math/rand"
+	"slices"
 )
 
+// GetSample returns a random selection of N items in the slice in the original order.
+// The elements are copied using assignment, so this is a shallow clone.
 func GetSample[T any](sampleCount int, data []T) []T {
-	if sampleCount < 1 || sampleCount > len(data) {
-		return data
+	var (
+		keys = make([]int, len(data))
+		copy []T
+	)
+	if sampleCount < 1 || sampleCount >= len(data) {
+		return slices.Clone(data)
 	}
-	rand.Shuffle(len(data), func(i, j int) {
-		data[i], data[j] = data[j], data[i]
+	for i := range keys {
+		keys[i] = i
+	}
+	rand.Shuffle(len(keys), func(i, j int) {
+		keys[i], keys[j] = keys[j], keys[i]
 	})
-	return data[:sampleCount]
+	keys = keys[:sampleCount]
+	slices.Sort(keys)
+	copy = make([]T, sampleCount)
+	for i := range keys {
+		copy[i] = data[keys[i]]
+	}
+	return copy
 }

--- a/sampler.go
+++ b/sampler.go
@@ -2,44 +2,14 @@ package opslevel_common
 
 import (
 	"math/rand"
-	"sort"
-	"time"
 )
 
-func getSamples(start int, end int, count int) []int {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
-	if end < start || (end-start) < count {
-		return nil
-	}
-	nums := make([]int, 0)
-	for len(nums) < count {
-		num := rand.Intn(end-start) + start
-		exist := false
-		for _, v := range nums {
-			if v == num {
-				exist = true
-				break
-			}
-		}
-		if !exist {
-			nums = append(nums, num)
-		}
-	}
-	sort.Ints(nums)
-	return nums
-}
-
 func GetSample[T any](sampleCount int, data []T) []T {
-	if sampleCount < 1 {
+	if sampleCount < 1 || sampleCount > len(data) {
 		return data
 	}
-	totalItems := len(data)
-	if sampleCount >= totalItems {
-		return data
-	}
-	output := make([]T, sampleCount)
-	for i, index := range getSamples(0, totalItems, sampleCount) {
-		output[i] = data[index]
-	}
-	return output
+	rand.Shuffle(len(data), func(i, j int) {
+		data[i], data[j] = data[j], data[i]
+	})
+	return data[:sampleCount]
 }

--- a/sampler.go
+++ b/sampler.go
@@ -2,69 +2,30 @@ package opslevel_common
 
 import (
 	"math/rand"
-	"sort"
-	"time"
+	"slices"
 )
-
-func getSamples(start int, end int, count int) []int {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
-	if end < start || (end-start) < count {
-		return nil
-	}
-	nums := make([]int, 0)
-	for len(nums) < count {
-		num := rand.Intn(end-start) + start
-		exist := false
-		for _, v := range nums {
-			if v == num {
-				exist = true
-				break
-			}
-		}
-		if !exist {
-			nums = append(nums, num)
-		}
-	}
-	sort.Ints(nums)
-	return nums
-}
-
-func GetSample[T any](sampleCount int, data []T) []T {
-	if sampleCount < 1 {
-		return data
-	}
-	totalItems := len(data)
-	if sampleCount >= totalItems {
-		return data
-	}
-	output := make([]T, sampleCount)
-	for i, index := range getSamples(0, totalItems, sampleCount) {
-		output[i] = data[index]
-	}
-	return output
-}
 
 // GetSample returns a random selection of N items in the slice in the original order.
 // The elements are copied using assignment, so this is a shallow clone.
-// func GetSample[T any](sampleCount int, data []T) []T {
-// 	var (
-// 		keys = make([]int, len(data))
-// 		copy []T
-// 	)
-// 	if sampleCount < 1 || sampleCount >= len(data) {
-// 		return slices.Clone(data)
-// 	}
-// 	for i := range keys {
-// 		keys[i] = i
-// 	}
-// 	rand.Shuffle(len(keys), func(i, j int) {
-// 		keys[i], keys[j] = keys[j], keys[i]
-// 	})
-// 	keys = keys[:sampleCount]
-// 	slices.Sort(keys)
-// 	copy = make([]T, sampleCount)
-// 	for i := range keys {
-// 		copy[i] = data[keys[i]]
-// 	}
-// 	return copy
-// }
+func GetSample[T any](sampleCount int, data []T) []T {
+	var (
+		keys = make([]int, len(data))
+		copy []T
+	)
+	if sampleCount < 1 || sampleCount >= len(data) {
+		return slices.Clone(data)
+	}
+	for i := range keys {
+		keys[i] = i
+	}
+	rand.Shuffle(len(keys), func(i, j int) {
+		keys[i], keys[j] = keys[j], keys[i]
+	})
+	keys = keys[:sampleCount]
+	slices.Sort(keys)
+	copy = make([]T, sampleCount)
+	for i := range keys {
+		copy[i] = data[keys[i]]
+	}
+	return copy
+}

--- a/sampler.go
+++ b/sampler.go
@@ -2,30 +2,69 @@ package opslevel_common
 
 import (
 	"math/rand"
-	"slices"
+	"sort"
+	"time"
 )
+
+func getSamples(start int, end int, count int) []int {
+	rand.New(rand.NewSource(time.Now().UnixNano()))
+	if end < start || (end-start) < count {
+		return nil
+	}
+	nums := make([]int, 0)
+	for len(nums) < count {
+		num := rand.Intn(end-start) + start
+		exist := false
+		for _, v := range nums {
+			if v == num {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			nums = append(nums, num)
+		}
+	}
+	sort.Ints(nums)
+	return nums
+}
+
+func GetSample[T any](sampleCount int, data []T) []T {
+	if sampleCount < 1 {
+		return data
+	}
+	totalItems := len(data)
+	if sampleCount >= totalItems {
+		return data
+	}
+	output := make([]T, sampleCount)
+	for i, index := range getSamples(0, totalItems, sampleCount) {
+		output[i] = data[index]
+	}
+	return output
+}
 
 // GetSample returns a random selection of N items in the slice in the original order.
 // The elements are copied using assignment, so this is a shallow clone.
-func GetSample[T any](sampleCount int, data []T) []T {
-	var (
-		keys = make([]int, len(data))
-		copy []T
-	)
-	if sampleCount < 1 || sampleCount >= len(data) {
-		return slices.Clone(data)
-	}
-	for i := range keys {
-		keys[i] = i
-	}
-	rand.Shuffle(len(keys), func(i, j int) {
-		keys[i], keys[j] = keys[j], keys[i]
-	})
-	keys = keys[:sampleCount]
-	slices.Sort(keys)
-	copy = make([]T, sampleCount)
-	for i := range keys {
-		copy[i] = data[keys[i]]
-	}
-	return copy
-}
+// func GetSample[T any](sampleCount int, data []T) []T {
+// 	var (
+// 		keys = make([]int, len(data))
+// 		copy []T
+// 	)
+// 	if sampleCount < 1 || sampleCount >= len(data) {
+// 		return slices.Clone(data)
+// 	}
+// 	for i := range keys {
+// 		keys[i] = i
+// 	}
+// 	rand.Shuffle(len(keys), func(i, j int) {
+// 		keys[i], keys[j] = keys[j], keys[i]
+// 	})
+// 	keys = keys[:sampleCount]
+// 	slices.Sort(keys)
+// 	copy = make([]T, sampleCount)
+// 	for i := range keys {
+// 		copy[i] = data[keys[i]]
+// 	}
+// 	return copy
+// }

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetSample(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		n    int
 		data []string
 		want []string
@@ -29,7 +29,7 @@ func TestGetSample(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		var testname = fmt.Sprintf("n is %d slice is %v want", tt.n, tt.data)
+		testname := fmt.Sprintf("n is %d slice is %v want", tt.n, tt.data)
 		if tt.want != nil {
 			testname += fmt.Sprintf(" %v", tt.want)
 		} else {
@@ -37,7 +37,7 @@ func TestGetSample(t *testing.T) {
 		}
 
 		t.Run(testname, func(t *testing.T) {
-			var result = opslevel_common.GetSample(tt.n, tt.data)
+			result := opslevel_common.GetSample(tt.n, tt.data)
 
 			if len(result) != tt.n && tt.n > 1 && tt.n < len(result) {
 				t.Error("incorrect length")
@@ -49,7 +49,7 @@ func TestGetSample(t *testing.T) {
 				}
 			} else {
 				// applies to test cases only - should not have duplicate elements
-				var entries = map[string]struct{}{}
+				entries := map[string]struct{}{}
 				for i, elem := range result {
 					if _, ok := entries[elem]; ok {
 						t.Errorf("result elem %v pos %d not unique", elem, i)
@@ -59,7 +59,7 @@ func TestGetSample(t *testing.T) {
 				deepCopy := append([]string(nil), result...)
 				slices.Sort(deepCopy)
 				for i := range result {
-					var a, b = deepCopy[i], result[i]
+					a, b := deepCopy[i], result[i]
 					if a != b {
 						t.Errorf("result is not sorted, got sorted value '%s' vs result '%s", a, b)
 					}

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -1,0 +1,75 @@
+package opslevel_common_test
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+
+	opslevel_common "github.com/opslevel/opslevel-common/v2023"
+)
+
+func TestGetSample(t *testing.T) {
+	var tests = []struct {
+		n    int
+		data []string
+		want []string
+	}{
+		{-1, []string{"A", "B"}, []string{"A", "B"}}, // edge case N < 0
+		{0, []string{"A", "B"}, []string{"A", "B"}},  // edge case N < 1
+		{2, []string{"A", "B"}, []string{"A", "B"}},  // edge case N == len(data)
+		{0, []string{}, []string{}},                  // edge case N == len(data) == 0
+		{1, []string{"A"}, []string{"A"}},            // edge case N == len(data) == 1
+		{3, []string{"A", "B"}, []string{"A", "B"}},  // edge case N > len(data)
+
+		// test case slices must be written in ascending alphabetical order without
+		// any duplicates otherwise verifying correctness will be impossible.
+		// if the function is correct, C could never be before A or B.
+		{5, []string{"A", "B", "C", "D", "E", "F", "G"}, nil},
+	}
+
+	for _, tt := range tests {
+		var testname = fmt.Sprintf("n is %d slice is %v want", tt.n, tt.data)
+		if tt.want != nil {
+			testname += fmt.Sprintf(" %v", tt.want)
+		} else {
+			testname += " ordered output."
+		}
+
+		t.Run(testname, func(t *testing.T) {
+			var result = opslevel_common.GetSample(tt.n, tt.data)
+
+			if len(result) != tt.n && tt.n > 1 && tt.n < len(result) {
+				t.Error("incorrect length")
+			}
+
+			if tt.want != nil {
+				if !reflect.DeepEqual(tt.want, result) {
+					t.Error("edge case: result != want")
+				}
+			} else {
+				// applies to test cases only - should not have duplicate elements
+				var entries = map[string]struct{}{}
+				for i, elem := range result {
+					if _, ok := entries[elem]; ok {
+						t.Errorf("result elem %v pos %d not unique", elem, i)
+					}
+					entries[elem] = struct{}{}
+				}
+				deepCopy := append([]string(nil), result...)
+				slices.Sort(deepCopy)
+				for i := range result {
+					var a, b = deepCopy[i], result[i]
+					if a != b {
+						t.Errorf("result is not sorted, got sorted value '%s' vs result '%s", a, b)
+					}
+				}
+			}
+
+			// addresses should not match (returns a shallow pointer)
+			if &tt.data == &result {
+				t.Errorf("data pointer %p should not match result pointer %p", &tt.data, &result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/OpsLevel/kubectl-opslevel/pull/235 & https://github.com/OpsLevel/opslevel-k8s-controller/pull/18

The unit test passes on the old & new version of the code, see [this commit's](https://github.com/OpsLevel/opslevel-common/pull/44/commits/24fa9d67efbd40739ea48061f3cc0dae23582bd9) [CI run.](https://github.com/OpsLevel/opslevel-common/actions/runs/7517551935/job/20463847296)

---

`rand.seed()` calls [are not necessary after Go 1.20 unless you want consistent random values.](https://pkg.go.dev/math/rand#Shuffle)
